### PR TITLE
Added a python_requires.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ setup(
     description='A api wrapper for the bing apis.',
     long_description_content_type='text/markdown',
     long_description=open('README.md').read(),
+    python_requires=">=3.7"
     install_requires=[
         'aiohttp',
         'asyncio',


### PR DESCRIPTION
I have made this pull request because aiohttp only works with python 3.7 or higher.